### PR TITLE
Adding initialValues prop to Form

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -40,6 +40,7 @@ class Form extends Component<IFormProps & BoxProps, IFormState> {
     onSubmitError: undefined,
     onInvalidForm: undefined,
     onValidForm: undefined,
+    initialValues: {},
     object: {},
     tag: 'form',
     basis: 'medium',
@@ -50,7 +51,7 @@ class Form extends Component<IFormProps & BoxProps, IFormState> {
   constructor(props) {
     super(props);
     this.state = {
-      errors: undefined, submitted: false, data: { ...props.object },
+      errors: undefined, submitted: false, data: { ...props.initialValues, ...props.object },
     };
   }
 


### PR DESCRIPTION
Because the object prop makes this a controlled component. When the object prop is set, it is not possible to change the fields. With this extra property the developer can chose to use this in a controlled or uncontrolled manner.