### PR TITLE
fix: PagingTable, Page number is not updating on click of + or -

### DIFF
--- a/src/components/PagingTable/components/Pagination.tsx
+++ b/src/components/PagingTable/components/Pagination.tsx
@@ -62,13 +62,7 @@ export default class ReactTablePagination extends Component<
     super(props, context);
     this.state = { page: props.page };
   }
-
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      page: nextProps.page,
-    };
-  }
-
+  
   getSafePage = page => {
     const pg = Number.isNaN(page) ? this.props.page : page;
     return Math.min(Math.max(pg, 0), this.props.pages - 1);


### PR DESCRIPTION
1.nextProps in getDerivedStateFromProps lifycycle is overriding the updated state to older values. Hence removed the life cycle method. Without this pagination works properly.